### PR TITLE
Accept many tfplan files in a single `submit-plan` invocation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,3 +45,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.53
+          skip-pkg-cache: true

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Upload a terraform plan to overmind for Blast Radius Analysis:
 
 ```
 terraform show -json ./tfplan > ./tfplan.json
-ovm-cli submit-plan --title "example change" --plan-json ./tfplan.json
+ovm-cli submit-plan --title "example change" ./tfplan1.json ./tfplan2.json ./tfplan3.json
 ```
 
 ## Terraform ➡ Overmind Mapping

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -316,3 +316,11 @@ func initConfig() {
 	viper.SetEnvKeyReplacer(replacer)
 	viper.AutomaticEnv() // read in environment variables that match
 }
+
+// must panics if the passed in error is not nil
+// use this for init-time error checking of viper/cobra stuff that sometimes errors if the flag does not exist
+func must(err error) {
+	if err != nil {
+		panic(fmt.Errorf("error initialising: %w", err))
+	}
+}

--- a/cmd/submitplan_test.go
+++ b/cmd/submitplan_test.go
@@ -2,21 +2,13 @@ package cmd
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 )
 
 func TestChangingItemQueriesFromPlan(t *testing.T) {
-	testFile := "testdata/plan.json"
-	planJSON, err := os.ReadFile(testFile)
-
-	if err != nil {
-		t.Errorf("Error reading %v: %v", testFile, err)
-	}
-
-	queries, err := changingItemQueriesFromPlan(context.Background(), planJSON, logrus.Fields{})
+	queries, err := changingItemQueriesFromPlan(context.Background(), "testdata/plan.json", logrus.Fields{})
 
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
This is necessary for example when using terragrunt with multiple modules.

Fixes https://github.com/overmindtech/ovm-cli/issues/55