### PR TITLE
Implement a --otel flag to globally disable tracing and error collecting

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -266,13 +266,14 @@ func init() {
 	rootCmd.PersistentFlags().String("auth0-domain", "om-prod.eu.auth0.com", "Auth0 domain to connect to")
 
 	// tracing
-	rootCmd.PersistentFlags().String("honeycomb-api-key", "", "If specified, configures opentelemetry libraries to submit traces to honeycomb")
-	rootCmd.PersistentFlags().String("sentry-dsn", "", "If specified, configures sentry libraries to capture errors")
+	rootCmd.PersistentFlags().Bool("otel", false, "If specified, configures opentelemetry and - optionally, see --sentry-dsn - sentry using their default environment configs.")
+	rootCmd.PersistentFlags().String("honeycomb-api-key", "", "If specified, configures opentelemetry libraries to submit traces to honeycomb. This requires --otel to be set.")
+	rootCmd.PersistentFlags().String("sentry-dsn", "", "If specified, configures sentry libraries to capture errors. This requires --otel to be set.")
 	rootCmd.PersistentFlags().String("run-mode", "release", "Set the run mode for this service, 'release', 'debug' or 'test'. Defaults to 'release'.")
-	rootCmd.PersistentFlags().Bool("json-log", false, "Set to true to emit logs as json for easier parsing")
+	rootCmd.PersistentFlags().Bool("json-log", false, "Set to true to emit logs as json for easier parsing.")
 
 	// debugging
-	rootCmd.PersistentFlags().Bool("stdout-trace-dump", false, "Dump all otel traces to stdout for debugging")
+	rootCmd.PersistentFlags().Bool("stdout-trace-dump", false, "Dump all otel traces to stdout for debugging. This requires --otel to be set.")
 
 	// Run this before we do anything to set up the loglevel
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {

--- a/tracing/main.go
+++ b/tracing/main.go
@@ -86,7 +86,7 @@ func tracingResource() *resource.Resource {
 var tp *sdktrace.TracerProvider
 
 func InitTracerWithHoneycomb(key string, opts ...otlptracehttp.Option) error {
-	if key != "" {
+	if key != "" && viper.GetBool("otel") {
 		opts = append(opts,
 			otlptracehttp.WithEndpoint("api.honeycomb.io"),
 			otlptracehttp.WithHeaders(map[string]string{"x-honeycomb-team": key}),
@@ -96,30 +96,32 @@ func InitTracerWithHoneycomb(key string, opts ...otlptracehttp.Option) error {
 }
 
 func InitTracer(opts ...otlptracehttp.Option) error {
-	if sentry_dsn := viper.GetString("sentry-dsn"); sentry_dsn != "" {
-		var environment string
-		if viper.GetString("run-mode") == "release" {
-			environment = "prod"
-		} else {
-			environment = "dev"
+	if viper.GetBool("otel") {
+		if sentry_dsn := viper.GetString("sentry-dsn"); sentry_dsn != "" {
+			var environment string
+			if viper.GetString("run-mode") == "release" {
+				environment = "prod"
+			} else {
+				environment = "dev"
+			}
+			err := sentry.Init(sentry.ClientOptions{
+				Dsn:              sentry_dsn,
+				AttachStacktrace: true,
+				EnableTracing:    false,
+				Environment:      environment,
+				// Set TracesSampleRate to 1.0 to capture 100%
+				// of transactions for performance monitoring.
+				// We recommend adjusting this value in production,
+				TracesSampleRate: 1.0,
+			})
+			if err != nil {
+				log.Errorf("sentry.Init: %s", err)
+			}
+			// setup recovery for an unexpected panic in this function
+			defer sentry.Flush(2 * time.Second)
+			defer sentry.Recover()
+			log.Info("sentry configured")
 		}
-		err := sentry.Init(sentry.ClientOptions{
-			Dsn:              sentry_dsn,
-			AttachStacktrace: true,
-			EnableTracing:    false,
-			Environment:      environment,
-			// Set TracesSampleRate to 1.0 to capture 100%
-			// of transactions for performance monitoring.
-			// We recommend adjusting this value in production,
-			TracesSampleRate: 1.0,
-		})
-		if err != nil {
-			log.Errorf("sentry.Init: %s", err)
-		}
-		// setup recovery for an unexpected panic in this function
-		defer sentry.Flush(2 * time.Second)
-		defer sentry.Recover()
-		log.Info("sentry configured")
 	}
 
 	client := otlptracehttp.NewClient(opts...)
@@ -129,21 +131,28 @@ func InitTracer(opts ...otlptracehttp.Option) error {
 	}
 	log.Infof("otlptracehttp client configured itself: %v", client)
 
-	tracerOpts := []sdktrace.TracerProviderOption{
-		sdktrace.WithBatcher(otlpExp, sdktrace.WithMaxQueueSize(50000)),
-		sdktrace.WithResource(tracingResource()),
-		sdktrace.WithSampler(sdktrace.ParentBased(NewUserAgentSampler("ELB-HealthChecker/2.0", 200))),
-	}
-	if viper.GetBool("stdout-trace-dump") {
-		stdoutExp, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
-		if err != nil {
-			return err
+	tracerOpts := []sdktrace.TracerProviderOption{}
+
+	if viper.GetBool("otel") {
+		tracerOpts = []sdktrace.TracerProviderOption{
+			sdktrace.WithBatcher(otlpExp, sdktrace.WithMaxQueueSize(50000)),
+			sdktrace.WithResource(tracingResource()),
+			sdktrace.WithSampler(sdktrace.ParentBased(NewUserAgentSampler("ELB-HealthChecker/2.0", 200))),
 		}
-		tracerOpts = append(tracerOpts, sdktrace.WithBatcher(stdoutExp))
+
+		if viper.GetBool("stdout-trace-dump") {
+			stdoutExp, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
+			if err != nil {
+				return err
+			}
+			tracerOpts = append(tracerOpts, sdktrace.WithBatcher(stdoutExp))
+		}
 	}
 	tp = sdktrace.NewTracerProvider(tracerOpts...)
 	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+	if viper.GetBool("otel") {
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+	}
 	return nil
 }
 


### PR DESCRIPTION
```
vscode ➜ /workspace/ovm-cli (dev) $ go run main.go request --query foo
INFO[0000] set log level from config                     fields.level=info
INFO[0000] otlptracehttp client configured itself: &{traces {localhost:4318 false <nil> map[] 0 10000000000 /v1/traces <nil>} {{localhost:4318 false <nil> map[] 0 10000000000 /v1/traces <nil>} {true 5000000000 30000000000 60000000000} 0  [] <nil>} 0xd1e680 0xc00067dce0 0xc000048300 {0 {0 0}}} 
ERRO[0000] failed to authenticate                        api-key-url="https://api.df.overmind-demo.com" error="error authenticating the API token: unauthenticated: API key not found"
exit status 1
vscode ➜ /workspace/ovm-cli (dev) $ OTEL=true go run main.go request --query foo
INFO[0000] set log level from config                     fields.level=info
INFO[0000] otlptracehttp client configured itself: &{traces {api.honeycomb.io false <nil> map[x-honeycomb-team:Quu6uCifruYihvi1Lzj3MC] 0 10000000000 /v1/traces <nil>} {{api.honeycomb.io false <nil> map[x-honeycomb-team:Quu6uCifruYihvi1Lzj3MC] 0 10000000000 /v1/traces <nil>} {true 5000000000 30000000000 60000000000} 0  [] <nil>} 0xd1e680 0xc00014b650 0xc0000484e0 {0 {0 0}}} 
ERRO[0000] failed to authenticate                        api-key-url="https://api.df.overmind-demo.com" error="error authenticating the API token: unauthenticated: API key not found"
exit status 1
vscode ➜ /workspace/ovm-cli (dev) $ 
```


Fixes https://github.com/overmindtech/ovm-cli/issues/54