### PR TITLE
Handle signals at the command level

### DIFF
--- a/cmd/getbookmark.go
+++ b/cmd/getbookmark.go
@@ -35,13 +35,25 @@ var getBookmarkCmd = &cobra.Command{
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
-		exitcode := GetBookmark(sigs, nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Create a goroutine to watch for cancellation signals
+		go func() {
+			select {
+			case <-sigs:
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+
+		exitcode := GetBookmark(ctx, nil)
 		tracing.ShutdownTracer()
 		os.Exit(exitcode)
 	},
 }
 
-func GetBookmark(signals chan os.Signal, ready chan bool) int {
+func GetBookmark(ctx context.Context, ready chan bool) int {
 	timeout, err := time.ParseDuration(viper.GetString("timeout"))
 	if err != nil {
 		log.Errorf("invalid --timeout value '%v', error: %v", viper.GetString("timeout"), err)
@@ -54,13 +66,12 @@ func GetBookmark(signals chan os.Signal, ready chan bool) int {
 		return 1
 	}
 
-	ctx := context.Background()
 	ctx, span := tracing.Tracer().Start(ctx, "CLI GetBookmark", trace.WithAttributes(
 		attribute.String("om.config", fmt.Sprintf("%v", viper.AllSettings())),
 	))
 	defer span.End()
 
-	ctx, err = ensureToken(ctx, []string{"changes:read"}, signals)
+	ctx, err = ensureToken(ctx, []string{"changes:read"})
 	if err != nil {
 		log.WithContext(ctx).WithError(err).WithFields(log.Fields{
 			"url": viper.GetString("url"),

--- a/cmd/getsnapshot.go
+++ b/cmd/getsnapshot.go
@@ -35,13 +35,25 @@ var getSnapshotCmd = &cobra.Command{
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
-		exitcode := GetSnapshot(sigs, nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Create a goroutine to watch for cancellation signals
+		go func() {
+			select {
+			case <-sigs:
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+
+		exitcode := GetSnapshot(ctx, nil)
 		tracing.ShutdownTracer()
 		os.Exit(exitcode)
 	},
 }
 
-func GetSnapshot(signals chan os.Signal, ready chan bool) int {
+func GetSnapshot(ctx context.Context, ready chan bool) int {
 	timeout, err := time.ParseDuration(viper.GetString("timeout"))
 	if err != nil {
 		log.Errorf("invalid --timeout value '%v', error: %v", viper.GetString("timeout"), err)
@@ -54,13 +66,12 @@ func GetSnapshot(signals chan os.Signal, ready chan bool) int {
 		return 1
 	}
 
-	ctx := context.Background()
 	ctx, span := tracing.Tracer().Start(ctx, "CLI GetSnapshot", trace.WithAttributes(
 		attribute.String("om.config", fmt.Sprintf("%v", viper.AllSettings())),
 	))
 	defer span.End()
 
-	ctx, err = ensureToken(ctx, []string{"changes:read"}, signals)
+	ctx, err = ensureToken(ctx, []string{"changes:read"})
 	if err != nil {
 		log.WithContext(ctx).WithError(err).WithFields(log.Fields{
 			"url": viper.GetString("url"),

--- a/cmd/request.go
+++ b/cmd/request.go
@@ -42,19 +42,30 @@ var requestCmd = &cobra.Command{
 
 		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
-		exitcode := Request(sigs, nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Create a goroutine to watch for cancellation signals
+		go func() {
+			select {
+			case <-sigs:
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+
+		exitcode := Request(ctx, nil)
 		tracing.ShutdownTracer()
 		os.Exit(exitcode)
 	},
 }
 
-func Request(signals chan os.Signal, ready chan bool) int {
+func Request(ctx context.Context, ready chan bool) int {
 	timeout, err := time.ParseDuration(viper.GetString("timeout"))
 	if err != nil {
 		log.Errorf("invalid --timeout value '%v', error: %v", viper.GetString("timeout"), err)
 		return 1
 	}
-	ctx := context.Background()
 	ctx, span := tracing.Tracer().Start(ctx, "CLI Request", trace.WithAttributes(
 		attribute.String("om.config", fmt.Sprintf("%v", viper.AllSettings())),
 	))
@@ -75,7 +86,7 @@ func Request(signals chan os.Signal, ready chan bool) int {
 
 	lf := log.Fields{}
 
-	ctx, err = ensureToken(ctx, []string{"explore:read"}, signals)
+	ctx, err = ensureToken(ctx, []string{"explore:read"})
 	if err != nil {
 		log.WithContext(ctx).WithFields(lf).WithField("api-key-url", viper.GetString("api-key-url")).WithError(err).Error("failed to authenticate")
 		return 1
@@ -166,10 +177,6 @@ func Request(signals chan os.Signal, ready chan bool) int {
 responses:
 	for {
 		select {
-		case <-signals:
-			log.WithContext(ctx).WithFields(lf).Info("Received interrupt, exiting")
-			return 1
-
 		case <-ctx.Done():
 			log.WithContext(ctx).WithFields(lf).Info("Context cancelled, exiting")
 			return 1
@@ -283,9 +290,6 @@ responses:
 
 		for {
 			select {
-			case <-signals:
-				log.WithContext(ctx).Info("Received interrupt, exiting")
-				return 1
 			case <-ctx.Done():
 				log.WithContext(ctx).Info("Context cancelled, exiting")
 				return 1

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,7 @@ func Execute() {
 }
 
 // ensureToken
-func ensureToken(ctx context.Context, requiredScopes []string, signals chan os.Signal) (context.Context, error) {
+func ensureToken(ctx context.Context, requiredScopes []string) (context.Context, error) {
 	// get a token from the api key if present
 	if viper.GetString("api-key") != "" {
 		log.WithContext(ctx).Debug("using provided token for authentication")
@@ -198,9 +198,8 @@ func ensureToken(ctx context.Context, requiredScopes []string, signals chan os.S
 		select {
 		case token = <-tokenChan:
 			// Keep working
-		case <-signals:
-			log.WithContext(ctx).Debug("Received interrupt, exiting")
-			return ctx, errors.New("cancelled")
+		case <-ctx.Done():
+			return ctx, ctx.Err()
 		}
 
 		// Stop the server

--- a/cmd/startchange.go
+++ b/cmd/startchange.go
@@ -33,26 +33,37 @@ var startChangeCmd = &cobra.Command{
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
-		exitcode := StartChange(sigs, nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Create a goroutine to watch for cancellation signals
+		go func() {
+			select {
+			case <-sigs:
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+
+		exitcode := StartChange(ctx, nil)
 		tracing.ShutdownTracer()
 		os.Exit(exitcode)
 	},
 }
 
-func StartChange(signals chan os.Signal, ready chan bool) int {
+func StartChange(ctx context.Context, ready chan bool) int {
 	timeout, err := time.ParseDuration(viper.GetString("timeout"))
 	if err != nil {
 		log.Errorf("invalid --timeout value '%v', error: %v", viper.GetString("timeout"), err)
 		return 1
 	}
 
-	ctx := context.Background()
 	ctx, span := tracing.Tracer().Start(ctx, "CLI StartChange", trace.WithAttributes(
 		attribute.String("om.config", fmt.Sprintf("%v", viper.AllSettings())),
 	))
 	defer span.End()
 
-	ctx, err = ensureToken(ctx, []string{"changes:write"}, signals)
+	ctx, err = ensureToken(ctx, []string{"changes:write"})
 	if err != nil {
 		log.WithContext(ctx).WithFields(log.Fields{
 			"url": viper.GetString("url"),


### PR DESCRIPTION
This means we can use a context to propagate cancellation, which is what they are designed for. Seems like this is a more elegant solution

@DavidS-om Can I please get a preliminary review on this and I'll add to my current PR if approved?