### PR TITLE
submit plans with attribute details 

### DIFF
--- a/cmd/datamaps/awssource.go
+++ b/cmd/datamaps/awssource.go
@@ -501,6 +501,30 @@ var AwssourceData = map[string][]TfMapData{
 			Scope:      "*",
 		},
 	},
+	"aws_networkfirewall_firewall": {
+		{
+			Type:       "network-firewall-firewall",
+			Method:     sdp.QueryMethod_GET,
+			QueryField: "name",
+			Scope:      "*",
+		},
+	},
+	"aws_networkfirewall_firewall_policy": {
+		{
+			Type:       "network-firewall-firewall-policy",
+			Method:     sdp.QueryMethod_GET,
+			QueryField: "name",
+			Scope:      "*",
+		},
+	},
+	"aws_networkfirewall_rule_group": {
+		{
+			Type:       "network-firewall-rule-group",
+			Method:     sdp.QueryMethod_GET,
+			QueryField: "name",
+			Scope:      "*",
+		},
+	},
 	"aws_placement_group": {
 		{
 			Type:       "ec2-placement-group",

--- a/cmd/submitplan.go
+++ b/cmd/submitplan.go
@@ -221,7 +221,7 @@ func changingItemQueriesFromPlan(ctx context.Context, fileName string, lf log.Fi
 			// Populate resource values
 			dataMap["values"] = currentResource.AttributeValues
 
-			if overmindMappings, ok := plan.PlannedValues.Outputs["overmind_mappings"]; ok {
+			if overmindMappingsOutput, ok := plan.PlannedValues.Outputs["overmind_mappings"]; ok {
 				configResource := plan.Config.RootModule.DigResource(resourceChange.Address)
 
 				if configResource == nil {
@@ -233,7 +233,7 @@ func changingItemQueriesFromPlan(ctx context.Context, fileName string, lf log.Fi
 					// Look up the provider config key in the mappings
 					mappings := make(map[string]map[string]string)
 
-					err = json.Unmarshal(overmindMappings.Value, &mappings)
+					err = json.Unmarshal(overmindMappingsOutput.Value, &mappings)
 
 					if err != nil {
 						log.WithContext(ctx).

--- a/cmd/submitplan_test.go
+++ b/cmd/submitplan_test.go
@@ -4,69 +4,156 @@ import (
 	"context"
 	"testing"
 
+	"github.com/overmindtech/sdp-go"
 	"github.com/sirupsen/logrus"
 )
 
-func TestChangingItemQueriesFromPlan(t *testing.T) {
-	mappedPlan, err := changingItemQueriesFromPlan(context.Background(), "testdata/plan.json", logrus.Fields{})
+func TestMappedItemDiffsFromPlan(t *testing.T) {
+	mappedItemDiffs, err := mappedItemDiffsFromPlan(context.Background(), "testdata/plan.json", logrus.Fields{})
 
 	if err != nil {
 		t.Error(err)
 	}
 
-	deployments, exists := mappedPlan.SupportedChanges["kubernetes_deployment"]
-
-	if !exists {
-		t.Errorf("Expected kubernetes_deployment to be in supported changes")
+	if len(mappedItemDiffs) != 4 {
+		t.Errorf("Expected 4 changes, got %v:", len(mappedItemDiffs))
+		for _, diff := range mappedItemDiffs {
+			t.Errorf("  %v", diff)
+		}
 	}
 
-	if len(deployments) != 2 {
-		t.Errorf("Expected 2 deployments, got %v", len(deployments))
+	var nats_box_deployment *sdp.MappedItemDiff
+	var api_server_deployment *sdp.MappedItemDiff
+	var aws_iam_policy *sdp.MappedItemDiff
+	var aws_iam_policy_document *sdp.MappedItemDiff
+
+	for _, diff := range mappedItemDiffs {
+		item := diff.Item.Before
+		if item == nil && diff.Item.After != nil {
+			item = diff.Item.After
+		}
+		if item == nil {
+			t.Errorf("Expected any of before/after items to be set, but there's nothing: %v", diff)
+			continue
+		}
+
+		// t.Logf("item: %v", item.Attributes.AttrStruct.Fields["terraform_address"].GetStringValue())
+		if item.Attributes.AttrStruct.Fields["terraform_address"].GetStringValue() == "kubernetes_deployment.nats_box" {
+			nats_box_deployment = diff
+		} else if item.Attributes.AttrStruct.Fields["terraform_address"].GetStringValue() == "kubernetes_deployment.api_server" {
+			api_server_deployment = diff
+		} else if item.Type == "iam-policy" {
+			aws_iam_policy = diff
+		} else if item.Type == "aws_iam_policy_document" {
+			aws_iam_policy_document = diff
+		}
 	}
 
-	if deployments[0].OvermindQuery.Type != "Deployment" {
-		t.Errorf("Expected query type to be Deployment, got %v", deployments[0].OvermindQuery.Type)
+	// check nats_box_deployment
+	t.Logf("nats_box_deployment: %v", nats_box_deployment)
+	if nats_box_deployment == nil {
+		t.Fatalf("Expected nats_box_deployment to be set, but it's not")
+	}
+	if nats_box_deployment.Item.Status != sdp.ItemDiffStatus_ITEM_DIFF_STATUS_DELETED {
+		t.Errorf("Expected nats_box_deployment status to be 'deleted', but it's '%v'", nats_box_deployment.Item.Status)
+	}
+	if nats_box_deployment.MappingQuery.Type != "Deployment" {
+		t.Errorf("Expected nats_box_deployment query type to be 'Deployment', got '%v'", nats_box_deployment.MappingQuery.Type)
+	}
+	if nats_box_deployment.MappingQuery.Query != "nats-box" {
+		t.Errorf("Expected nats_box_deployment query to be 'nats-box', got '%v'", nats_box_deployment.MappingQuery.Query)
+	}
+	if nats_box_deployment.MappingQuery.Scope != "*" {
+		t.Errorf("Expected nats_box_deployment query scope to be '*', got '%v'", nats_box_deployment.MappingQuery.Scope)
+	}
+	if nats_box_deployment.Item.Before.Scope != "terraform_plan" {
+		t.Errorf("Expected nats_box_deployment before item scope to be 'terraform_plan', got '%v'", nats_box_deployment.Item.Before.Scope)
+	}
+	if nats_box_deployment.MappingQuery.Type != "Deployment" {
+		t.Errorf("Expected nats_box_deployment query type to be 'Deployment', got '%v'", nats_box_deployment.MappingQuery.Type)
+	}
+	if nats_box_deployment.Item.Before.Type != "Deployment" {
+		t.Errorf("Expected nats_box_deployment before item type to be 'Deployment', got '%v'", nats_box_deployment.Item.Before.Type)
+	}
+	if nats_box_deployment.MappingQuery.Query != "nats-box" {
+		t.Errorf("Expected nats_box_deployment query query to be 'nats-box', got '%v'", nats_box_deployment.MappingQuery.Query)
 	}
 
-	if deployments[0].OvermindQuery.Query != "nats-box" {
-		t.Errorf("Expected query to be nats-box, got %v", deployments[0].OvermindQuery.Query)
+	// check api_server_deployment
+	t.Logf("api_server_deployment: %v", api_server_deployment)
+	if api_server_deployment == nil {
+		t.Fatalf("Expected api_server_deployment to be set, but it's not")
+	}
+	if api_server_deployment.Item.Status != sdp.ItemDiffStatus_ITEM_DIFF_STATUS_UPDATED {
+		t.Errorf("Expected api_server_deployment status to be 'updated', but it's '%v'", api_server_deployment.Item.Status)
+	}
+	if api_server_deployment.MappingQuery.Type != "Deployment" {
+		t.Errorf("Expected api_server_deployment query type to be 'Deployment', got '%v'", api_server_deployment.MappingQuery.Type)
+	}
+	if api_server_deployment.MappingQuery.Query != "api-server" {
+		t.Errorf("Expected api_server_deployment query to be 'api-server', got '%v'", api_server_deployment.MappingQuery.Query)
+	}
+	if api_server_deployment.MappingQuery.Scope != "dogfood.default" {
+		t.Errorf("Expected api_server_deployment query scope to be 'dogfood.default', got '%v'", api_server_deployment.MappingQuery.Scope)
+	}
+	if api_server_deployment.Item.Before.Scope != "dogfood.default" {
+		t.Errorf("Expected api_server_deployment before item scope to be 'dogfood.default', got '%v'", api_server_deployment.Item.Before.Scope)
+	}
+	if api_server_deployment.MappingQuery.Type != "Deployment" {
+		t.Errorf("Expected api_server_deployment query type to be 'Deployment', got '%v'", api_server_deployment.MappingQuery.Type)
+	}
+	if api_server_deployment.Item.Before.Type != "Deployment" {
+		t.Errorf("Expected api_server_deployment before item type to be 'Deployment', got '%v'", api_server_deployment.Item.Before.Type)
+	}
+	if api_server_deployment.MappingQuery.Query != "api-server" {
+		t.Errorf("Expected api_server_deployment query query to be 'api-server', got '%v'", api_server_deployment.MappingQuery.Query)
 	}
 
-	if deployments[0].OvermindQuery.Scope != "*" {
-		t.Errorf("Expected query scope to be *, got %v", deployments[0].OvermindQuery.Scope)
+	// check aws_iam_policy
+	t.Logf("aws_iam_policy: %v", aws_iam_policy)
+	if aws_iam_policy == nil {
+		t.Fatalf("Expected aws_iam_policy to be set, but it's not")
+	}
+	if aws_iam_policy.Item.Status != sdp.ItemDiffStatus_ITEM_DIFF_STATUS_UPDATED {
+		t.Errorf("Expected aws_iam_policy status to be 'updated', but it's %v", aws_iam_policy.Item.Status)
+	}
+	if aws_iam_policy.MappingQuery.Type != "iam-policy" {
+		t.Errorf("Expected aws_iam_policy query type to be 'iam-policy', got '%v'", aws_iam_policy.MappingQuery.Type)
+	}
+	if aws_iam_policy.MappingQuery.Query != "arn:aws:iam::123456789012:policy/test-alb-ingress" {
+		t.Errorf("Expected aws_iam_policy query to be 'arn:aws:iam::123456789012:policy/test-alb-ingress', got '%v'", aws_iam_policy.MappingQuery.Query)
+	}
+	if aws_iam_policy.MappingQuery.Scope != "*" {
+		t.Errorf("Expected aws_iam_policy query scope to be '*', got '%v'", aws_iam_policy.MappingQuery.Scope)
+	}
+	if aws_iam_policy.Item.Before.Scope != "terraform_plan" {
+		t.Errorf("Expected aws_iam_policy before item scope to be 'terraform_plan', got '%v'", aws_iam_policy.Item.Before.Scope)
+	}
+	if aws_iam_policy.MappingQuery.Type != "iam-policy" {
+		t.Errorf("Expected aws_iam_policy query type to be 'iam-policy', got '%v'", aws_iam_policy.MappingQuery.Type)
+	}
+	if aws_iam_policy.Item.Before.Type != "iam-policy" {
+		t.Errorf("Expected aws_iam_policy before item type to be 'iam-policy', got '%v'", aws_iam_policy.Item.Before.Type)
+	}
+	if aws_iam_policy.MappingQuery.Query != "arn:aws:iam::123456789012:policy/test-alb-ingress" {
+		t.Errorf("Expected aws_iam_policy query query to be 'arn:aws:iam::123456789012:policy/test-alb-ingress', got '%v'", aws_iam_policy.MappingQuery.Query)
 	}
 
-	if deployments[1].OvermindQuery.Type != "Deployment" {
-		t.Errorf("Expected query type to be Deployment, got %v", deployments[1].OvermindQuery.Type)
+	// check aws_iam_policy_document
+	t.Logf("aws_iam_policy_document: %v", aws_iam_policy_document)
+	if aws_iam_policy_document == nil {
+		t.Fatalf("Expected aws_iam_policy_document to be set, but it's not")
 	}
-
-	if deployments[1].OvermindQuery.Query != "api-server" {
-		t.Errorf("Expected query to be api-server, got %v", deployments[1].OvermindQuery.Query)
+	if aws_iam_policy_document.Item.Status != sdp.ItemDiffStatus_ITEM_DIFF_STATUS_UNCHANGED {
+		t.Errorf("Expected aws_iam_policy_document status to be 'unchanged', but it's %v", aws_iam_policy_document.Item.Status)
 	}
-
-	if deployments[1].OvermindQuery.Scope != "dogfood.default" {
-		t.Errorf("Expected query scope to be dogfood.default, got %v", deployments[1].OvermindQuery.Scope)
+	if aws_iam_policy_document.MappingQuery != nil {
+		t.Errorf("Expected aws_iam_policy_document query to be nil, got '%v'", aws_iam_policy_document.MappingQuery)
 	}
-
-	iamPolicies, exists := mappedPlan.SupportedChanges["aws_iam_policy"]
-
-	if !exists {
-		t.Errorf("Expected aws_iam_policy to be in supported changes")
+	if aws_iam_policy_document.Item.After.Scope != "terraform_plan" {
+		t.Errorf("Expected aws_iam_policy_document after item scope to be 'terraform_plan', got '%v'", aws_iam_policy_document.Item.After.Scope)
 	}
-
-	if len(iamPolicies) != 1 {
-		t.Errorf("Expected 1 iam policy, got %v", len(iamPolicies))
-	}
-
-	if iamPolicies[0].OvermindQuery.Type != "iam-policy" {
-		t.Errorf("Expected query type to be iam-policy, got %v", iamPolicies[0].OvermindQuery.Type)
-	}
-
-	if iamPolicies[0].OvermindQuery.Query != "arn:aws:iam::123456789012:policy/test-alb-ingress" {
-		t.Errorf("Expected query to be arn:aws:iam::123456789012:policy/test-alb-ingress, got %v", iamPolicies[0].OvermindQuery.Query)
-	}
-
-	if iamPolicies[0].OvermindQuery.Scope != "*" {
-		t.Errorf("Expected query scope to be *, got %v", iamPolicies[0].OvermindQuery.Scope)
+	if aws_iam_policy_document.Item.After.Type != "aws_iam_policy_document" {
+		t.Errorf("Expected aws_iam_policy_document after item type to be 'aws_iam_policy_document', got '%v'", aws_iam_policy_document.Item.After.Type)
 	}
 }

--- a/cmd/submitplan_test.go
+++ b/cmd/submitplan_test.go
@@ -15,8 +15,8 @@ func TestMappedItemDiffsFromPlan(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(mappedItemDiffs) != 4 {
-		t.Errorf("Expected 4 changes, got %v:", len(mappedItemDiffs))
+	if len(mappedItemDiffs) != 3 {
+		t.Errorf("Expected 3 changes, got %v:", len(mappedItemDiffs))
 		for _, diff := range mappedItemDiffs {
 			t.Errorf("  %v", diff)
 		}
@@ -25,7 +25,6 @@ func TestMappedItemDiffsFromPlan(t *testing.T) {
 	var nats_box_deployment *sdp.MappedItemDiff
 	var api_server_deployment *sdp.MappedItemDiff
 	var aws_iam_policy *sdp.MappedItemDiff
-	var aws_iam_policy_document *sdp.MappedItemDiff
 
 	for _, diff := range mappedItemDiffs {
 		item := diff.Item.Before
@@ -44,8 +43,6 @@ func TestMappedItemDiffsFromPlan(t *testing.T) {
 			api_server_deployment = diff
 		} else if item.Type == "iam-policy" {
 			aws_iam_policy = diff
-		} else if item.Type == "aws_iam_policy_document" {
-			aws_iam_policy_document = diff
 		}
 	}
 
@@ -137,23 +134,5 @@ func TestMappedItemDiffsFromPlan(t *testing.T) {
 	}
 	if aws_iam_policy.MappingQuery.Query != "arn:aws:iam::123456789012:policy/test-alb-ingress" {
 		t.Errorf("Expected aws_iam_policy query query to be 'arn:aws:iam::123456789012:policy/test-alb-ingress', got '%v'", aws_iam_policy.MappingQuery.Query)
-	}
-
-	// check aws_iam_policy_document
-	t.Logf("aws_iam_policy_document: %v", aws_iam_policy_document)
-	if aws_iam_policy_document == nil {
-		t.Fatalf("Expected aws_iam_policy_document to be set, but it's not")
-	}
-	if aws_iam_policy_document.Item.Status != sdp.ItemDiffStatus_ITEM_DIFF_STATUS_UNCHANGED {
-		t.Errorf("Expected aws_iam_policy_document status to be 'unchanged', but it's %v", aws_iam_policy_document.Item.Status)
-	}
-	if aws_iam_policy_document.MappingQuery != nil {
-		t.Errorf("Expected aws_iam_policy_document query to be nil, got '%v'", aws_iam_policy_document.MappingQuery)
-	}
-	if aws_iam_policy_document.Item.After.Scope != "terraform_plan" {
-		t.Errorf("Expected aws_iam_policy_document after item scope to be 'terraform_plan', got '%v'", aws_iam_policy_document.Item.After.Scope)
-	}
-	if aws_iam_policy_document.Item.After.Type != "aws_iam_policy_document" {
-		t.Errorf("Expected aws_iam_policy_document after item type to be 'aws_iam_policy_document', got '%v'", aws_iam_policy_document.Item.After.Type)
 	}
 }


### PR DESCRIPTION
This change improves data collection, so that overmind can show the changed attributes from all resources. Note that this does properly redact sensitive values so they do not get exposed to the service.

![2023-11-09_18MS+0100_1285x972](https://github.com/overmindtech/ovm-cli/assets/118179693/4726b973-a6b1-4ed9-b761-f513f6618d0a)

This fixes #109 